### PR TITLE
I’ve replaced the broken .deb installation with the official APT repo…

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,12 +27,14 @@ jobs:
       - name: Run TFLint
         run: tflint --init && tflint --recursive
 
-      - name: Install Trivy
+      - name: Install Trivy (Official APT Repo)
         run: |
           sudo apt-get update
-          sudo apt-get install wget -y
-          wget https://github.com/aquasecurity/trivy/releases/latest/download/trivy_Linux-64bit.deb -O trivy.deb
-          sudo dpkg -i trivy.deb
+          sudo apt-get install -y wget gnupg lsb-release apt-transport-https
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
 
       - name: Trivy Scan
         run: trivy fs --exit-code 1 --severity HIGH,CRITICAL .


### PR DESCRIPTION
…sitory, which works on Ubuntu 24.04 (the environment behind ubuntu-latest).

Updated Trivy installation to use the official APT repository and added necessary dependencies.